### PR TITLE
Fix class name typo in App component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,8 @@ function App() {
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="readjjk-the-docs">
-        Click on the Vite and Reacjdjdjdt logos to learn more
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
       </p>
     </>
   )


### PR DESCRIPTION
## Summary
- fix "read-the-docs" class name and text in App component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae4472bfc48325b7d438ef9ac4088f