### PR TITLE
chore: enable type-aware eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,13 +11,17 @@ export default tseslint.config([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
 ])


### PR DESCRIPTION
## Summary
- enable TypeScript-aware ESLint rules with `recommendedTypeChecked`
- configure ESLint parser to use app and node tsconfigs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ae6ba3883259838ec666b173122